### PR TITLE
Optimized get_current_tree so every commit is visited only once.

### DIFF
--- a/gitgud/operations.py
+++ b/gitgud/operations.py
@@ -133,7 +133,6 @@ class Operator:
         while len(commits) > 0:
             cur_commit = commits.pop()
             if cur_commit not in visited:
-                # print(curCommit.message)
                 for parent in cur_commit.parents:
                     commits.add(parent)
             visited.add(cur_commit)
@@ -150,6 +149,7 @@ class Operator:
             target = repo.commit('HEAD').message.strip()
         else:
             target = repo.head.ref.name
+
         tree['HEAD'] = {
             'target': target,
             'id': 'HEAD'


### PR DESCRIPTION
Fixed bad python so that every node in the commit tree is only visited once. Please note that this was only tested for a small set of cases and more robust unit testing should be considered in the future. 