### PR TITLE
Nicer output for `git gud levels` 

### DIFF
--- a/gitgud/__main__.py
+++ b/gitgud/__main__.py
@@ -161,10 +161,12 @@ class GitGud:
         for level in all_levels.values():
             # TODO Make pretty
             # TODO Add description
+            # 10 characters for the short IDs. 
             print("Level {:<10} :{:>2} challenge{}".format("\"" + level.name + "\"", len(level.challenges), ("", "s")[len(level.challenges) > 1]))
             count = 1
             for challenge in level.challenges.values():
-                print("    Challenge {:>2} : {:<10}".format(str(count), challenge.name))
+                # " " * 4
+                print("{}Challenge {:>2} : {:<10}".format(" " * 4, str(count), challenge.name))
                 count += 1
 
     def handle_challenges(self, args):

--- a/gitgud/__main__.py
+++ b/gitgud/__main__.py
@@ -159,7 +159,6 @@ class GitGud:
         print("Currently on level: \"{}\"\n".format(cur_level.name))
         
         for level in all_levels.values():
-            # TODO Make pretty
             # TODO Add description
             # 10 characters for the short IDs. 
             print("Level {:<10} :{:>2} challenge{}".format("\"" + level.name + "\"", len(level.challenges), ("", "s")[len(level.challenges) > 1]))

--- a/gitgud/__main__.py
+++ b/gitgud/__main__.py
@@ -165,7 +165,7 @@ class GitGud:
             print("Level {:<10} :{:>2} challenge{}".format("\"" + level.name + "\"", len(level.challenges), ("", "s")[len(level.challenges) > 1]))
             count = 1
             for challenge in level.challenges.values():
-                # " " * 4
+                # " " * (characters allocated for ID - 6)
                 print("{}Challenge {:>2} : {:<10}".format(" " * 4, str(count), challenge.name))
                 count += 1
 

--- a/gitgud/__main__.py
+++ b/gitgud/__main__.py
@@ -157,11 +157,15 @@ class GitGud:
         cur_level = self.file_operator.get_challenge().level
 
         print("Currently on level: \"{}\"\n".format(cur_level.name))
-
+        
         for level in all_levels.values():
             # TODO Make pretty
             # TODO Add description
-            print(level.name, ": {} challenges".format(len(level.challenges)))
+            print("Level {:<10} :{:>2} challenge{}".format("\"" + level.name + "\"", len(level.challenges), ("", "s")[len(level.challenges) > 1]))
+            count = 1
+            for challenge in level.challenges.values():
+                print("    Challenge {:>2} : {:<10}".format(str(count), challenge.name))
+                count += 1
 
     def handle_challenges(self, args):
         key_error_flag = False

--- a/gitgud/__main__.py
+++ b/gitgud/__main__.py
@@ -162,11 +162,9 @@ class GitGud:
             # TODO Add description
             # 10 characters for the short IDs. 
             print("Level {:<10} :{:>2} challenge{}".format("\"" + level.name + "\"", len(level.challenges), ("", "s")[len(level.challenges) > 1]))
-            count = 1
-            for challenge in level.challenges.values():
+            for index, challenge in enumerate(level.challenges.values()):
                 # " " * (characters allocated for ID - 6)
-                print("{}Challenge {:>2} : {:<10}".format(" " * 4, str(count), challenge.name))
-                count += 1
+                print("{}Challenge {:>2} : {:<10}".format(" " * 4, index + 1, challenge.name))
 
     def handle_challenges(self, args):
         key_error_flag = False
@@ -186,10 +184,9 @@ class GitGud:
         else:
             print("Challenges for level \"{}\" : \n".format(level.name))
 
-        count = 1
-        for challenge in level.challenges.values():
-            print(str(count) + ": " +challenge.name)
-            count += 1
+        
+        for index, challenge in enumerate(level.challenges.values()):
+            print(str(index + 1) + ": " + challenge.name)
 
     def handle_load(self, args):
         self.assert_initialized()


### PR DESCRIPTION
fixes #9 
There is prettier padding for the levels being printed, with them being lined up in columns.
The word "challenge"  is made plural or singular depending on how many challenges are in the level.
The challenges for each level are listed under each level, spaced so that the colons line up.
(Might want to squash and merge, the various commits in the branch just change comments -- sorry)