### PR TITLE
Open contributors window

### DIFF
--- a/gitgud/__main__.py
+++ b/gitgud/__main__.py
@@ -1,6 +1,7 @@
 import os
 import sys
 import subprocess
+import webbrowser
 
 import argparse
 
@@ -54,6 +55,7 @@ class GitGud:
         commit_parser = self.subparsers.add_parser('commit', help='Quickly create and commit a file', description='Quickly create and commit a file')
         goal_parser = self.subparsers.add_parser('goal', help='Show a description of the current goal', description='Show a description of the current goal')
         show_tree_parser = self.subparsers.add_parser('show-tree', help='Show the current state of the branching tree', description='Show the current state of the branching tree')
+        contrib_parser = self.subparsers.add_parser('contributers', help='Show all the contributers of the project', description='Show all the contributers of the project')
 
         help_parser.add_argument('command_name', metavar='<command>', nargs='?')
 
@@ -81,6 +83,7 @@ class GitGud:
             'commit': self.handle_commit,
             'goal': self.handle_goal,
             'show-tree': self.handle_show_tree,
+            'contributers': self.handle_contrib,
         }
 
     def is_initialized(self):
@@ -285,6 +288,10 @@ class GitGud:
 
     def handle_show_tree(self, args):
         show_tree()
+
+    def handle_contrib(self, args):
+        contrib_website = "https://github.com/bthayer2365/git-gud/graphs/contributors"
+        webbrowser.open_new(contrib_website)
 
     def parse(self):
         args, _ = self.parser.parse_known_args()


### PR DESCRIPTION
**Bug:**

Opening the contributors page on a existing window works fine. No issues after closing it.

But if the page is opened on a new window (there was no existing tab or window open), then the following error comes when the window is **closed**.

```
[Parent 9950, Gecko_IOThread] WARNING: pipe error (59): Connection reset by peer: file /build/firefox-WlAST4/firefox-69.0.2+build1/ipc/chromium/src/chrome/common/ipc_channel_posix.cc, line 358
[Parent 9950, Gecko_IOThread] WARNING: pipe error (131): Connection reset by peer: file /build/firefox-WlAST4/firefox-69.0.2+build1/ipc/chromium/src/chrome/common/ipc_channel_posix.cc, line 358

###!!! [Parent][RunMessage] Error: Channel closing: too late to send/recv, messages will be lost

^C
```
This runs in an infinite loop have to exit using (ctrl + C)