### PR TITLE
Allows a variable number of arguments to be passed into git hooks. 

### DIFF
--- a/gitgud/__main__.py
+++ b/gitgud/__main__.py
@@ -280,12 +280,12 @@ class GitGud:
         subprocess.call(["git", "log", "--graph", "--oneline", "--all"])
 
     def parse(self):
-        args = self.parser.parse_known_args()
-        if args[0].command is None:
+        args, badargs = self.parser.parse_known_args()
+        if args.command is None:
             self.parser.print_help()
         else:
             try:
-                self.command_dict[args[0].command](args[0])
+                self.command_dict[args.command](args)
             except InitializationError:
                 print("Git gud has not been initialized. Initialize using \"git gud start\"")
                 pass

--- a/gitgud/__main__.py
+++ b/gitgud/__main__.py
@@ -280,7 +280,7 @@ class GitGud:
         subprocess.call(["git", "log", "--graph", "--oneline", "--all"])
 
     def parse(self):
-        args, badargs = self.parser.parse_known_args()
+        args, _ = self.parser.parse_known_args()
         if args.command is None:
             self.parser.print_help()
         else:

--- a/gitgud/__main__.py
+++ b/gitgud/__main__.py
@@ -280,12 +280,12 @@ class GitGud:
         subprocess.call(["git", "log", "--graph", "--oneline", "--all"])
 
     def parse(self):
-        args = self.parser.parse_args()
-        if args.command is None:
+        args = self.parser.parse_known_args()
+        if args[0].command is None:
             self.parser.print_help()
         else:
             try:
-                self.command_dict[args.command](args)
+                self.command_dict[args[0].command](args[0])
             except InitializationError:
                 print("Git gud has not been initialized. Initialize using \"git gud start\"")
                 pass

--- a/gitgud/__main__.py
+++ b/gitgud/__main__.py
@@ -141,7 +141,7 @@ class GitGud:
         for git_hook_name, module_hook_name in all_hooks:
             with open(os.path.join(self.file_operator.hooks_path, git_hook_name), 'w+') as hook_file:
                 hook_file.write('#!/bin/sh' + os.linesep)
-                hook_file.write('cat - | ' + python_exec + ' -m gitgud.hooks.' + module_hook_name + ' $1' +os.linesep)
+                hook_file.write('cat - | ' + python_exec + ' -m gitgud.hooks.' + module_hook_name + ' "$@"' +os.linesep)
                 hook_file.write('exit 0' + os.linesep)
 
         print('Git Gud successfully setup in {}'.format(os.getcwd()))


### PR DESCRIPTION
Fixes #45.

This has been tested with a custom script using the git hook `prepare-commit-msg`, which takes up to three arguments. This test script has not been included in the pull request.

Not taking #77 into consideration, both the custom `prepare-commit-msg` python script and the already existing `post-rewrite` python script work with git hooks, despite the fact that they take different numbers of inputs.

(As an aside: my commits from the very beginning of my involvement are appearing in this PR thread, is this normal?)